### PR TITLE
Disable document interaction

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,6 +143,30 @@ class PSPDFKitView extends React.Component {
   };
 
   /**
+   * Enable all interaction with the document
+   */
+  enableDocumentInteraction = function () {
+    console.log('enableDocumentInteraction');
+      if (Platform.OS === 'ios') {
+          return NativeModules.PSPDFKitViewManager.enableDocumentInteraction(
+          findNodeHandle(this.refs.pdfView),
+        );
+      }
+    };
+
+  /**
+   * Disable all interaction with the document
+   */
+  disableDocumentInteraction = function () {
+    console.log('disableDocumentInteraction');
+      if (Platform.OS === 'ios') {
+        return NativeModules.PSPDFKitViewManager.disableDocumentInteraction(
+        findNodeHandle(this.refs.pdfView),
+      );
+    }
+  };
+
+  /**
    * Saves the currently opened document.
    *
    * Returns a promise resolving to true if the document was saved, and false otherwise.

--- a/ios/RCTPSPDFKit.xcodeproj/project.pbxproj
+++ b/ios/RCTPSPDFKit.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0756A13E29C2124C00D3462C /* NSExceptionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0756A13A29C2124B00D3462C /* NSExceptionError.swift */; };
 		0756A13F29C2124C00D3462C /* InstantDocumentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0756A13B29C2124B00D3462C /* InstantDocumentViewController.swift */; };
 		07D79CA52A086568006E90D7 /* PspdfkitMeasurementConvertor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07D79CA42A086568006E90D7 /* PspdfkitMeasurementConvertor.swift */; };
+		48ED3C322AE8605400416909 /* CustomThumbnailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48ED3C312AE8605400416909 /* CustomThumbnailViewController.swift */; };
 		6540D1841D89D22E00B8F94F /* RCTPSPDFKitManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 6540D1831D89D22E00B8F94F /* RCTPSPDFKitManager.m */; };
 		6572780C1D86AE7300A5E1A8 /* RCTConvert+PSPDFConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 657278071D86AE7300A5E1A8 /* RCTConvert+PSPDFConfiguration.m */; };
 		657278111D86AEC600A5E1A8 /* RCTConvert+PSPDFDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 657278101D86AEC600A5E1A8 /* RCTConvert+PSPDFDocument.m */; };
@@ -51,6 +52,7 @@
 		0756A13A29C2124B00D3462C /* NSExceptionError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSExceptionError.swift; sourceTree = "<group>"; };
 		0756A13B29C2124B00D3462C /* InstantDocumentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstantDocumentViewController.swift; sourceTree = "<group>"; };
 		07D79CA42A086568006E90D7 /* PspdfkitMeasurementConvertor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PspdfkitMeasurementConvertor.swift; sourceTree = "<group>"; };
+		48ED3C312AE8605400416909 /* CustomThumbnailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomThumbnailViewController.swift; sourceTree = "<group>"; };
 		6540D1821D89D22E00B8F94F /* RCTPSPDFKitManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPSPDFKitManager.h; sourceTree = "<group>"; };
 		6540D1831D89D22E00B8F94F /* RCTPSPDFKitManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPSPDFKitManager.m; sourceTree = "<group>"; };
 		657277151D8312EA00A5E1A8 /* libRCTPSPDFKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTPSPDFKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -89,6 +91,7 @@
 			isa = PBXGroup;
 			children = (
 				6540D1821D89D22E00B8F94F /* RCTPSPDFKitManager.h */,
+				48ED3C312AE8605400416909 /* CustomThumbnailViewController.swift */,
 				0756A13929C2124B00D3462C /* InstantDocumentInfo.swift */,
 				0756A13B29C2124B00D3462C /* InstantDocumentViewController.swift */,
 				0756A13A29C2124B00D3462C /* NSExceptionError.swift */,
@@ -219,6 +222,7 @@
 				F8C1A2E5202DCC9700E98192 /* RCTPSPDFKitViewManager.m in Sources */,
 				84545BA4210A5CCF00FBB0A7 /* RCTConvert+PSPDFAnnotation.m in Sources */,
 				6540D1841D89D22E00B8F94F /* RCTPSPDFKitManager.m in Sources */,
+				48ED3C322AE8605400416909 /* CustomThumbnailViewController.swift in Sources */,
 				84694AA822AFC7510077FD01 /* RCTConvert+UIBarButtonItem.m in Sources */,
 				0756A13E29C2124C00D3462C /* NSExceptionError.swift in Sources */,
 				84B9870023FC208600C6711A /* RCTConvert+PSPDFAnnotationChange.m in Sources */,

--- a/ios/RCTPSPDFKit/CustomThumbnailViewController.swift
+++ b/ios/RCTPSPDFKit/CustomThumbnailViewController.swift
@@ -1,0 +1,29 @@
+//
+//  CustomThumbnailViewController.swift
+//  react-native-pspdfkit
+//
+//  Created by Erhard Brand on 2023/10/24.
+//
+
+import PSPDFKit
+import PSPDFKitUI
+
+@objc public class CustomThumbnailViewController: ThumbnailViewController {
+    public override func pages(forFilter filter: ThumbnailViewFilter, groupingResultsBy groupSize: UInt, result resultHandler: @escaping (IndexSet) -> Void, completion: @escaping (Bool) -> Void) -> PSPDFKit.Progress? {
+        // Only shows pages with note annotations.
+        if filter == .annotations {
+            guard let pagesWithNoteAnnotations = document?.allAnnotations(of: .note).map({ $0.key.intValue }) else {
+                return nil
+            }
+
+            var annotationIndexes: IndexSet = []
+            pagesWithNoteAnnotations.forEach { annotationIndexes.insert($0) }
+
+            resultHandler(annotationIndexes)
+            completion(true)
+            return nil
+        }
+
+        return super.pages(forFilter: filter, groupingResultsBy: groupSize, result: resultHandler, completion: completion)
+    }
+}

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -61,6 +61,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray <NSString *> *)getLeftBarButtonItemsForViewMode:(NSString *)viewMode;
 - (NSArray <NSString *> *)getRightBarButtonItemsForViewMode:(NSString *)viewMode;
 
+/// Document interaction
+- (BOOL)enableDocumentInteraction;
+- (BOOL)disableDocumentInteraction;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -19,15 +19,24 @@
 
 @property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) UIScrollView *zoomView;
+@property (readonly, assign) BOOL documentInteractionEnabled;
 
 @end
 
 @implementation OverrideScrolling
 
+- (id)init {
+    if (self = [super init])  {
+        _documentInteractionEnabled = YES;
+    }
+    return self;
+}
+
 - (BOOL)enableInteraction:(BOOL)enable {
     if (_scrollView != nil && _zoomView != nil) {
         _scrollView.panGestureRecognizer.enabled = enable;
         _zoomView.panGestureRecognizer.enabled = enable;
+        _documentInteractionEnabled = enable;
         return YES;
     }
     return NO;
@@ -64,6 +73,14 @@
     _pdfController.annotationToolbarController.delegate = self;
       
     _overrideScrolling = [OverrideScrolling new];
+      
+      NSMutableArray *buttonItems = [NSMutableArray arrayWithArray:_pdfController.navigationItem.rightBarButtonItems];
+      // ** If using a custom image **
+      // UIBarButtonItem *newItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"myImage.png"] style:UIBarButtonItemStylePlain target:self action:@selector(buttonPressed)];
+      // ** If using a custom image **
+      UIBarButtonItem *newItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCompose target:self action:@selector(customButtonPressed)];
+      [buttonItems addObject:newItem];
+      [_pdfController.navigationItem setRightBarButtonItems:buttonItems forViewMode:PSPDFViewModeDocument animated:NO];
     
     // Store the closeButton's target and selector in order to call it later.
     _closeButtonAttributes = @{@"target" : _pdfController.closeButtonItem.target,
@@ -188,6 +205,10 @@
 
 - (BOOL)disableDocumentInteraction {
     return [self enableDocumentInteraction:NO];
+}
+
+- (void)customButtonPressed {
+    [self enableDocumentInteraction:![_overrideScrolling documentInteractionEnabled]];
 }
 
 // MARK: - PSPDFDocumentDelegate

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -196,11 +196,39 @@
     // Disable all interactions on the document itself
     _pdfController.interactions.allInteractions.enabled = enable;
     
+    // Hide all annotations, except for Ink and Highlight
+    PSPDFDocument *document = self.pdfController.document;
+    VALIDATE_DOCUMENT(document, nil);
+    NSDictionary<PSPDFDocumentPageNumber, NSArray<PSPDFAnnotation *> *> *inkAnnotations = [document allAnnotationsOfType:PSPDFAnnotationTypeInk];
     
+    for (id key in inkAnnotations) {
+        for (PSPDFAnnotation *annotation in inkAnnotations[key]) {
+            if (enable) {
+                annotation.flags |= PSPDFAnnotationFlagHidden;
+            } else {
+                annotation.flags &= ~PSPDFAnnotationFlagHidden;
+            }
+            [[NSNotificationCenter defaultCenter] postNotificationName:PSPDFAnnotationChangedNotification object:annotation userInfo:@{ PSPDFAnnotationChangedNotificationKeyPathKey : @[@"hidden"] }];
+        }
+    }
+    
+    NSDictionary<PSPDFDocumentPageNumber, NSArray<PSPDFAnnotation *> *> *highlightAnnotations = [document allAnnotationsOfType:PSPDFAnnotationTypeHighlight];
+    
+    for (id key in highlightAnnotations) {
+        for (PSPDFAnnotation *annotation in highlightAnnotations[key]) {
+            if (enable) {
+                annotation.flags |= PSPDFAnnotationFlagHidden;
+            } else {
+                annotation.flags &= ~PSPDFAnnotationFlagHidden;
+            }
+            [[NSNotificationCenter defaultCenter] postNotificationName:PSPDFAnnotationChangedNotification object:annotation userInfo:@{ PSPDFAnnotationChangedNotificationKeyPathKey : @[@"hidden"] }];
+        }
+    }
     
     // Disable ScrollView panGestureRecognizer
     return [_overrideScrolling enableInteraction:enable];
 }
+
 
 - (BOOL)enableDocumentInteraction {
     return [self enableDocumentInteraction:YES];

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -12,6 +12,7 @@
 #import "RCTConvert+PSPDFAnnotation.h"
 #import "RCTConvert+PSPDFViewMode.h"
 #import "RCTConvert+UIBarButtonItem.h"
+#import "PSPDFKitReactNativeiOS-Swift.h"
 
 #define VALIDATE_DOCUMENT(document, ...) { if (!document.isValid) { NSLog(@"Document is invalid."); if (self.onDocumentLoadFailed) { self.onDocumentLoadFailed(@{@"error": @"Document is invalid."}); } return __VA_ARGS__; }}
 
@@ -71,6 +72,10 @@
     _pdfController = [[RCTPSPDFKitViewController alloc] init];
     _pdfController.delegate = self;
     _pdfController.annotationToolbarController.delegate = self;
+    
+    [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder * _Nonnull builder) {
+        [builder overrideClass:PSPDFThumbnailViewController.self withClass:CustomThumbnailViewController.self];
+    }];
       
     _overrideScrolling = [OverrideScrolling new];
       

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -74,14 +74,6 @@
       
     _overrideScrolling = [OverrideScrolling new];
       
-      NSMutableArray *buttonItems = [NSMutableArray arrayWithArray:_pdfController.navigationItem.rightBarButtonItems];
-      // ** If using a custom image **
-      // UIBarButtonItem *newItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"myImage.png"] style:UIBarButtonItemStylePlain target:self action:@selector(buttonPressed)];
-      // ** If using a custom image **
-      UIBarButtonItem *newItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCompose target:self action:@selector(customButtonPressed)];
-      [buttonItems addObject:newItem];
-      [_pdfController.navigationItem setRightBarButtonItems:buttonItems forViewMode:PSPDFViewModeDocument animated:NO];
-    
     // Store the closeButton's target and selector in order to call it later.
     _closeButtonAttributes = @{@"target" : _pdfController.closeButtonItem.target,
                               @"action" : NSStringFromSelector(_pdfController.closeButtonItem.action)};
@@ -192,8 +184,19 @@
 
 - (BOOL)enableDocumentInteraction:(BOOL)enable {
     
+    // Hide the toolbar & HUD
+    [_pdfController.navigationController setNavigationBarHidden:!enable animated:YES];
+    [_pdfController.annotationToolbarController hideToolbarAnimated:!enable completion:nil];
+    [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder * _Nonnull builder) {
+        builder.pageLabelEnabled = enable;
+        builder.documentLabelEnabled = enable;
+        builder.thumbnailBarMode = enable ? PSPDFThumbnailBarModeFloatingScrubberBar : PSPDFThumbnailBarModeNone;
+    }];
+    
     // Disable all interactions on the document itself
     _pdfController.interactions.allInteractions.enabled = enable;
+    
+    
     
     // Disable ScrollView panGestureRecognizer
     return [_overrideScrolling enableInteraction:enable];
@@ -205,10 +208,6 @@
 
 - (BOOL)disableDocumentInteraction {
     return [self enableDocumentInteraction:NO];
-}
-
-- (void)customButtonPressed {
-    [self enableDocumentInteraction:![_overrideScrolling documentInteractionEnabled]];
 }
 
 // MARK: - PSPDFDocumentDelegate

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -228,6 +228,30 @@ RCT_EXPORT_METHOD(exitCurrentlyActiveMode:(nonnull NSNumber *)reactTag resolver:
   });
 }
 
+RCT_EXPORT_METHOD(enableDocumentInteraction:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
+    BOOL success = [component enableDocumentInteraction];
+    if (success) {
+      resolve(@(success));
+    } else {
+      reject(@"error", @"Failed to enable document interaction.", nil);
+    }
+  });
+}
+
+RCT_EXPORT_METHOD(disableDocumentInteraction:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
+    BOOL success = [component disableDocumentInteraction];
+    if (success) {
+      resolve(@(success));
+    } else {
+      reject(@"error", @"Failed to disable document interaction.", nil);
+    }
+  });
+}
+
 RCT_EXPORT_METHOD(saveCurrentDocument:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];

--- a/samples/Catalog/Catalog.js
+++ b/samples/Catalog/Catalog.js
@@ -30,6 +30,7 @@ import { SaveAs } from './examples/SaveAs';
 import { SplitPDF } from './examples/SplitPDF';
 import { StateChange } from './examples/StateChange';
 import { ToolbarCustomization } from './examples/ToolbarCustomization';
+import { HeaderButtonsProvider } from 'react-navigation-header-buttons';
 import { PSPDFKit } from './helpers/PSPDFKit';
 
 // By default, this example doesn't set a license key, but instead runs in trial mode (which is the default, and which requires no
@@ -56,6 +57,7 @@ class Catalog extends Component {
 
     return (
       <NavigationContainer>
+        <HeaderButtonsProvider stackType={'native'}>
         <Stack.Navigator>
           <Stack.Screen name="Home" component={HomeScreen} />
           {/*initial={true} />*/}
@@ -107,6 +109,7 @@ class Catalog extends Component {
             initial={true}
           />
         </Stack.Navigator>
+        </HeaderButtonsProvider>
       </NavigationContainer>
     );
   }

--- a/samples/Catalog/examples/PSPDFKitViewComponent.js
+++ b/samples/Catalog/examples/PSPDFKitViewComponent.js
@@ -6,13 +6,40 @@ import { exampleDocumentPath, pspdfkitColor } from '../configuration/Constants';
 import { BaseExampleAutoHidingHeaderComponent } from '../helpers/BaseExampleAutoHidingHeaderComponent';
 import { hideToolbar } from '../helpers/NavigationHelper';
 
+import { MaterialHeaderButtons } from '../helpers/MyHeaderButtons';
+import { Item } from 'react-navigation-header-buttons';
+
 export class PSPDFKitViewComponent extends BaseExampleAutoHidingHeaderComponent {
   pdfRef = null;
+  documentInteractionEnabled = true;
+
   constructor(props) {
     super(props);
     const { navigation } = this.props;
     this.pdfRef = React.createRef();
     hideToolbar(navigation);
+    navigation.setOptions({
+      headerRight: () => (
+        <MaterialHeaderButtons>
+          <Item
+            title="add"
+            iconName="lock-outline"
+            onPress={() => this.toggleDocumentInteraction()}
+          />
+          {/* Adding blank button to add padding */}
+          <Item
+              title=""
+              iconName=""
+            />
+        </MaterialHeaderButtons>
+      ),
+    });
+  }
+
+  async toggleDocumentInteraction() {
+
+    this.documentInteractionEnabled ? await this.pdfRef.current.disableDocumentInteraction() : await this.pdfRef.current.enableDocumentInteraction();
+    this.documentInteractionEnabled = !this.documentInteractionEnabled
   }
 
   render() {

--- a/samples/Catalog/helpers/MyHeaderButtons.js
+++ b/samples/Catalog/helpers/MyHeaderButtons.js
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+import { HeaderButtons, HeaderButton } from 'react-navigation-header-buttons';
+
+// define IconComponent, color, sizes and OverflowIcon in one place
+const MaterialHeaderButton = (props) => (
+  <HeaderButton
+    IconComponent={MaterialIcons}
+    iconSize={23}
+    color="blue"
+    {...props}
+  />
+);
+
+export const MaterialHeaderButtons = (props) => {
+  return (
+    <HeaderButtons HeaderButtonComponent={MaterialHeaderButton} {...props} />
+  );
+};

--- a/samples/Catalog/ios/Catalog/Info.plist
+++ b/samples/Catalog/ios/Catalog/Info.plist
@@ -61,6 +61,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIAppFonts</key>
+	<array>
+		<string>MaterialIcons.ttf</string>
+	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>

--- a/samples/Catalog/ios/Podfile.lock
+++ b/samples/Catalog/ios/Podfile.lock
@@ -76,12 +76,12 @@ PODS:
   - hermes-engine (0.71.8):
     - hermes-engine/Pre-built (= 0.71.8)
   - hermes-engine/Pre-built (0.71.8)
-  - Instant (12.4.0-dev)
+  - Instant (12.3.1)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
-  - PSPDFKit (12.4.0-dev):
-    - PSPDFKit/Core (= 12.4.0-dev)
-  - PSPDFKit/Core (12.4.0-dev)
+  - PSPDFKit (12.3.1):
+    - PSPDFKit/Core (= 12.3.1)
+  - PSPDFKit/Core (12.3.1)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -333,7 +333,7 @@ PODS:
   - React-jsinspector (0.71.8)
   - React-logger (0.71.8):
     - glog
-  - react-native-pspdfkit (2.6.1):
+  - react-native-pspdfkit (2.7.0):
     - Instant
     - PSPDFKit
     - React
@@ -438,6 +438,8 @@ PODS:
   - RNScreens (3.20.0):
     - React-Core
     - React-RCTImage
+  - RNVectorIcons (10.0.0):
+    - React-Core
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -471,10 +473,10 @@ DEPENDENCIES:
   - FlipperKit/SKIOSNetworkPlugin (= 0.125.0)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
-  - Instant (from `https://customers.pspdfkit.com/instant/nightly.podspec`)
+  - Instant (~> 12.3.1)
   - libevent (~> 2.1.12)
   - OpenSSL-Universal (= 1.1.1100)
-  - PSPDFKit (from `https://customers.pspdfkit.com/pspdfkit-ios/nightly.podspec`)
+  - PSPDFKit (~> 12.3.1)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
@@ -511,6 +513,7 @@ DEPENDENCIES:
   - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNScreens (from `../node_modules/react-native-screens`)
+  - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -526,8 +529,10 @@ SPEC REPOS:
     - Flipper-RSocket
     - FlipperKit
     - fmt
+    - Instant
     - libevent
     - OpenSSL-Universal
+    - PSPDFKit
     - SocketRocket
     - YogaKit
 
@@ -544,10 +549,6 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
-  Instant:
-    :podspec: https://customers.pspdfkit.com/instant/nightly.podspec
-  PSPDFKit:
-    :podspec: https://customers.pspdfkit.com/pspdfkit-ios/nightly.podspec
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -616,6 +617,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-gesture-handler"
   RNScreens:
     :path: "../node_modules/react-native-screens"
+  RNVectorIcons:
+    :path: "../node_modules/react-native-vector-icons"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -637,10 +640,10 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 47986d26692ae75ee7a17ab049caee8864f855de
-  Instant: 4951b6c445fc87741ab3e49e917d971472b42335
+  Instant: 1d43d2ac05f1ec51c04d896e492ad9d7efa0a20d
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  PSPDFKit: b2d8a35e8e2662c4a5c93f7c8463107dccfd7f6b
+  PSPDFKit: 25758dd47ee422ff60cf8761099f6cd583e3af6e
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 8af6a32dfc2b65ec82193c2dee6e1011ff22ac2a
   RCTTypeSafety: bee9dd161c175896c680d47ef1d9eaacf2b587f4
@@ -655,7 +658,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 747911ab5921641b4ed7e4900065896597142125
   React-jsinspector: c712f9e3bb9ba4122d6b82b4f906448b8a281580
   React-logger: 342f358b8decfbf8f272367f4eacf4b6154061be
-  react-native-pspdfkit: 62b32a4e09f1bff1ad80b5adadb67ad55e6585f3
+  react-native-pspdfkit: 7717a2ca3bca954b76b41cb8db8b011d19c8abd2
   react-native-safe-area: e8230b0017d76c00de6b01e2412dcf86b127c6a3
   react-native-safe-area-context: b8979f5eda6ed5903d4dbc885be3846ea3daa753
   React-perflogger: d21f182895de9d1b077f8a3cd00011095c8c9100
@@ -675,10 +678,11 @@ SPEC CHECKSUMS:
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: f75d81410b40aaa99e71ae8f8bb7a88620c95042
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
+  RNVectorIcons: 8b5bb0fa61d54cd2020af4f24a51841ce365c7e9
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 065f0b74dba4832d6e328238de46eb72c5de9556
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 699a0bd86ccd09b1ff2b6bbb2c0feb65df1032ab
+PODFILE CHECKSUM: 8f4074fe503df8accbc576bd59103f77404efe36
 
 COCOAPODS: 1.12.1

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -33,7 +33,9 @@
     "react-native-safe-area": "^0.5.1",
     "react-native-safe-area-context": "^4.5.3",
     "react-native-screens": "^3.20.0",
-    "react-native-windows": "^0.71.15"
+    "react-native-vector-icons": "^10.0.0",
+    "react-native-windows": "^0.71.15",
+    "react-navigation-header-buttons": "^11.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.22.1",

--- a/samples/Catalog/yarn.lock
+++ b/samples/Catalog/yarn.lock
@@ -6640,6 +6640,14 @@ react-native-screens@^3.20.0:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
+react-native-vector-icons@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-10.0.0.tgz#0f031f7717f76f0a397f725de9b5a47ec87862e9"
+  integrity sha512-efMOVbZIebY8RszZPzPBoXi9pvD/NFYmjIDYxRoc9LYSzV8rMJtT8FfcO2hPu85Rn2x9xktha0+qn0B7EqMAcQ==
+  dependencies:
+    prop-types "^15.7.2"
+    yargs "^16.1.1"
+
 react-native-windows@^0.71.15:
   version "0.71.15"
   resolved "https://registry.yarnpkg.com/react-native-windows/-/react-native-windows-0.71.15.tgz#c3f761490ebbf4001497916052c9c52bf070412e"
@@ -6721,6 +6729,13 @@ react-native@0.71.8:
     whatwg-fetch "^3.0.0"
     ws "^6.2.2"
 
+react-navigation-header-buttons@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/react-navigation-header-buttons/-/react-navigation-header-buttons-11.0.1.tgz#500b7aba39e067d2dbc8722549b53a82670f35ff"
+  integrity sha512-RYKCVDWaDp9YFNT8kAuEEEdbmv8LcXvj7GtbukIt5oVA5mivV5JsLB5HaR78/Qs9f9xHbLP0lJn4Ao5joYBycw==
+  dependencies:
+    react-to-imperative "^0.2.0"
+
 react-refresh@^0.4.0:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.3.tgz#966f1750c191672e76e16c2efa569150cc73ab53"
@@ -6742,6 +6757,11 @@ react-test-renderer@18.2.0:
     react-is "^18.2.0"
     react-shallow-renderer "^16.15.0"
     scheduler "^0.23.0"
+
+react-to-imperative@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/react-to-imperative/-/react-to-imperative-0.2.0.tgz#b5f1603a6aba352ae37b6c4ddec0759956b4c063"
+  integrity sha512-MK5hZlTkgz7yk3MZLIxoDa75d9wxAecLS6y6HPD8C/rwdv/2Zezisbs8TzEq9azkHiII9UEQJTTlSlKdiq9xsg==
 
 react@^18.2.0:
   version "18.2.0"
@@ -8015,7 +8035,7 @@ yargs@^15.1.0:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yargs@^16.2.0:
+yargs@^16.1.1, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==


### PR DESCRIPTION
Example implementation to disable or enable all document interaction.

**Usage:**
```
await this.pdfRef.current.disableDocumentInteraction();
```
**or**
```
await this.pdfRef.current.enableDocumentInteraction();
```

The current example implementation will add a new button to the iOS implementation, which will toggle whether the document interaction is enabled or not:

![Screenshot 2023-09-20 at 16 54 35](https://github.com/PSPDFKit-labs/react-native/assets/141146947/aa3f6545-ad70-49d5-bebc-ac3873e886d5)